### PR TITLE
Small change to allow the default option to be false.

### DIFF
--- a/lib/flavors/preferences/preferences.rb
+++ b/lib/flavors/preferences/preferences.rb
@@ -26,10 +26,8 @@ module Flavors
     def read_preference(name, default = nil)
       if p = self.preferences.where(:name => name).first
         p.value
-      elsif default.present?
-        default
       else
-        nil
+        default
       end
     end
 


### PR DESCRIPTION
I had an issue setting false as the default value. The expression default.present? will return false if the value of default is false, causing the method to continue to the else clause, returning nil. Since default will always be set to nil if it is not present (as per the method definition), there is no need to check for the presence of a default value.
